### PR TITLE
fix single arg method

### DIFF
--- a/src/Contract/Function/Function.js
+++ b/src/Contract/Function/Function.js
@@ -22,7 +22,7 @@ class Function extends Component {
     submit = () => {
         let p = this.state.params
         let paramsArray = []
-        if (Object.keys(p).length === 1 && p[""] !== undefined) {
+        if (Object.keys(p).length === 1 && !!p[""]) {
             paramsArray.push(p[""])
         } else {
             for (const input of this.props.inputs) {

--- a/src/Contract/Function/Function.js
+++ b/src/Contract/Function/Function.js
@@ -22,7 +22,7 @@ class Function extends Component {
     submit = () => {
         let p = this.state.params
         let paramsArray = []
-        if (Object.keys(p).length === 1 && p[""] !== null) {
+        if (Object.keys(p).length === 1 && p[""] !== undefined) {
             paramsArray.push(p[""])
         } else {
             for (const input of this.props.inputs) {


### PR DESCRIPTION
After checking it came to my attention that single argument methods are not working properly. I don't know exactly when `p[""]` can be set but this condition is more sustainable agains when value is not `undefined `or `null` or `false`.